### PR TITLE
WIP Better union representation for Swift

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,11 +28,12 @@ set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_CURRENT_SOURCE_DIR}/build/
 file (STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/configure.ac" CONFIGURE_AC REGEX "AC_INIT\\(.*\\)" )
 
 # The following variable is used in the version.h.in file
-string(REGEX REPLACE "AC_INIT\\(\\[.*\\], \\[([0-9]+\\.[0-9]+\\.[0-9]+(-dev)?)\\]\\)" "\\1" PACKAGE_VERSION ${CONFIGURE_AC})
+#string(REGEX REPLACE "AC_INIT\\(\\[.*\\], \\[([0-9]+\\.[0-9]+\\.[0-9]+(-dev)?)\\]\\)" "\\1" PACKAGE_VERSION ${CONFIGURE_AC})
+string(REGEX REPLACE "AC_INIT\\(\\[.*\\], \\[([0-9]+\\.[0-9]+\\.[0-9]+(-dev)?(\\.[a-z0-9-]+)?)\\]\\)" "\\1" PACKAGE_VERSION ${CONFIGURE_AC})
 message(STATUS "Parsed Thrift package version: ${PACKAGE_VERSION}")
 
 # These are internal to CMake
-string(REGEX REPLACE "([0-9]+\\.[0-9]+\\.[0-9]+)(-dev)?" "\\1" thrift_VERSION ${PACKAGE_VERSION})
+string(REGEX REPLACE "([0-9]+\\.[0-9]+\\.[0-9]+)(-dev)?(\\.[a-z0-9-]+)" "\\1" thrift_VERSION ${PACKAGE_VERSION})
 string(REGEX REPLACE "([0-9]+)\\.[0-9]+\\.[0-9]+" "\\1" thrift_VERSION_MAJOR ${thrift_VERSION})
 string(REGEX REPLACE "[0-9]+\\.([0-9])+\\.[0-9]+" "\\1" thrift_VERSION_MINOR ${thrift_VERSION})
 string(REGEX REPLACE "[0-9]+\\.[0-9]+\\.([0-9]+)" "\\1" thrift_VERSION_PATCH ${thrift_VERSION})

--- a/compiler/cpp/src/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/generate/t_swift_generator.cc
@@ -572,7 +572,7 @@ void t_swift_generator::generate_swift_struct_hashable_extension(ofstream& out,
       t_field* tfield = *m_iter;
       string accessor = field_is_optional(tfield) ? "?." : ".";
       string defaultor = field_is_optional(tfield) ? " ?? 0" : "";
-      indent(out) << "result = prime * result + (" << maybe_escape_identifier(tfield->get_name()) << accessor
+      indent(out) << "result = prime &* result &+ (" << maybe_escape_identifier(tfield->get_name()) << accessor
                   <<  "hashValue" << defaultor << ")" << endl;
     }
     

--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,7 @@
 AC_PREREQ(2.65)
 AC_CONFIG_MACRO_DIR([./aclocal])
 
-AC_INIT([thrift], [1.0.0-dev])
+AC_INIT([thrift], [1.0.0-dev.zedge-20160408.2])
 
 AC_CONFIG_AUX_DIR([.])
 


### PR DESCRIPTION
Swift has enumerations with associated values, which seems like a
natural representation of union structs.

This would convert a union as
 union Foo {
  1: Bar bar
  2: Baz baz
}

into a Swift definition like

enum Foo {
  case bar(Bar)
  case baz(Baz)
  case ThriftUnknownValue
}

WIP: untested and needs better errors in some cases.
